### PR TITLE
feat: add fe container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,19 @@ services:
       - db_data:/var/lib/postgresql/data
     networks:
       - nivlalulu-network
+  fe:
+    container_name: frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - 5000:5000
+    volumes:
+      - ./frontend/src:/app/src
+      - ./frontend/public:/app/public
+      - /app/node_modules
+    networks:
+      - nivlalulu-network
 
   lb:
     container_name: lb


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file to add a new frontend service. The most important changes include defining the frontend service with its container name, build context, ports, volumes, and network configuration.

Changes to `docker-compose.yml`:

* Added a new service `fe` with the container name `frontend`.
* Defined the build context and Dockerfile for the frontend service.
* Configured ports mapping for the frontend service to expose port 5000.
* Added volumes to map the frontend source and public directories, as well as the node_modules directory.
* Included the frontend service in the `nivlalulu-network` network.