### PR TITLE
fix: expose correct port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - 8080:8080
+      - 8443:8443
     environment:
       - SPRING_PROFILES_ACTIVE=docker
     env_file:


### PR DESCRIPTION
This pull request includes a change to the `docker-compose.yml` file to update the port mapping for the backend service.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R8): Changed the port mapping from `8080:8080` to `8443:8443` for the backend service.